### PR TITLE
Touch up trait module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,19 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bigdecimal"
@@ -20,12 +29,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
@@ -50,9 +53,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "downcast-rs"
@@ -92,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "indexmap"
@@ -114,9 +117,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -130,27 +133,27 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-bigint"
@@ -220,6 +223,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,9 +259,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -289,6 +321,7 @@ dependencies = [
  "downcast-rs",
  "indexmap",
  "num-bigint",
+ "regex",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -380,15 +413,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -397,30 +430,40 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -432,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -442,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -455,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -472,10 +515,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bytebuffer = "2.3.0"
 thiserror = "2.0.17"
 indexmap = "2.11.4"
 downcast-rs = "2.0.2"
+regex = "1.11.2"
 
 [workspace.lints.rust]
 future-incompatible = "warn"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,8 @@ bytebuffer.workspace = true
 indexmap.workspace = true
 thiserror.workspace = true
 downcast-rs.workspace = true
+regex.workspace = true
+
 serde = { version = "1.0", features = ["derive"] }
 static_str_ops = "0.1.2"
 rustc-hash = "2.1.1"

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -76,6 +76,7 @@ macro_rules! static_trait_id {
 #[macro_export]
 macro_rules! annotation_trait {
     ($trait_struct:ident, $id_var:ident, $id_name:literal) => {
+        #[derive(Debug)]
         pub struct $trait_struct {}
         impl $trait_struct {
             #[must_use]
@@ -96,6 +97,41 @@ macro_rules! annotation_trait {
 
             fn value(&self) -> &DocumentValue {
                 &DocumentValue::Null
+            }
+        }
+    };
+}
+
+// Trait definitions that contain only a string value
+#[macro_export]
+macro_rules! string_trait {
+    ($trait_struct:ident, $id_var:ident, $value_name:ident, $id_name:literal) => {
+        #[derive(Debug)]
+        pub struct $trait_struct {
+            $value_name: String,
+            value: DocumentValue,
+        }
+        impl $trait_struct {
+            pub fn $value_name(&self) -> &str {
+                &self.$value_name
+            }
+
+            #[must_use]
+            pub fn new($value_name: &str) -> Self {
+                $trait_struct {
+                    $value_name: $value_name.to_string(),
+                    value: DocumentValue::String($value_name.to_string()),
+                }
+            }
+        }
+        static_trait_id!($trait_struct, $id_var, $id_name);
+        impl SmithyTrait for $trait_struct {
+            fn id(&self) -> &ShapeId {
+                $trait_struct::trait_id()
+            }
+
+            fn value(&self) -> &DocumentValue {
+                &self.value
             }
         }
     };

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -6,7 +6,7 @@
 macro_rules! traits {
     () => { Vec::new() };
     ($($x:expr),+ $(,)?) => (
-        vec![$(Ref::new($x)),*]
+        vec![$($x.into()),*]
     );
 }
 
@@ -49,6 +49,14 @@ macro_rules! lazy_schema {
             .build()
         });
     };
+    (
+        $schema_name:ident,
+        $builder:expr
+    ) => {
+        pub static $schema_name: LazyLock<SchemaRef> = LazyLock::new(|| {
+            $builder
+        });
+    };
 }
 
 // Create a lazy, static ShapeId
@@ -65,6 +73,7 @@ macro_rules! static_trait_id {
     ($trait_struct:ident, $id_var:ident, $id_name:literal) => {
         lazy_shape_id!($id_var, $id_name);
         impl StaticTraitId for $trait_struct {
+            #[inline]
             fn trait_id() -> &'static ShapeId {
                 &$id_var
             }

--- a/core/src/schema/documents.rs
+++ b/core/src/schema/documents.rs
@@ -60,6 +60,11 @@ impl Document {
             _ => 1,
         }
     }
+
+    /// Converts a type into a document
+    pub fn from<V: Into<Document>>(value: V) -> Document {
+        value.into()
+    }
 }
 
 impl SchemaShape for Document {

--- a/core/src/schema/schemas.rs
+++ b/core/src/schema/schemas.rs
@@ -657,7 +657,7 @@ mod tests {
         let json_name_value = schema
             .get_trait_as::<JsonNameTrait>()
             .expect("No Json Name trait present");
-        assert_eq!(json_name_value.name, "other")
+        assert_eq!(json_name_value.name(), "other")
     }
 
     #[test]
@@ -674,6 +674,6 @@ mod tests {
         let json_name_value = member
             .get_trait_as::<JsonNameTrait>()
             .expect("No JSON name trait present");
-        assert_eq!(json_name_value.name, "other");
+        assert_eq!(json_name_value.name(), "other");
     }
 }

--- a/core/src/schema/schemas.rs
+++ b/core/src/schema/schemas.rs
@@ -315,13 +315,13 @@ impl Schema {
     /// Returns true if the map contains a value for the specified trait ID.
     #[must_use]
     pub fn contains_trait(&self, id: &ShapeId) -> bool {
-        self.traits().contains_trait(id)
+        self.traits().contains(id)
     }
 
     /// Returns true if the map contains a trait of type `T`.
     #[must_use]
-    pub fn contains_trait_type<T: StaticTraitId>(&self) -> bool {
-        self.traits().contains_trait_type::<T>()
+    pub fn contains_type<T: StaticTraitId>(&self) -> bool {
+        self.traits().contains_type::<T>()
     }
 
     /// Gets a [`SmithyTrait`] as a specific implementation if it exists.
@@ -329,14 +329,14 @@ impl Schema {
     /// If the [`SmithyTrait`] does not exist on this schema, returns `None`.
     #[must_use]
     pub fn get_trait_as<T: SmithyTrait + StaticTraitId>(&self) -> Option<&T> {
-        self.traits().get_trait_as::<T>()
+        self.traits().get_as::<T>()
     }
 
     /// Get a dynamic implementation of a [`SmithyTrait`] by shape ID.
     ///
     /// If the [`SmithyTrait`] does not exist on this schema, returns `None`.
     #[must_use]
-    pub fn get_trait_dyn(&self, id: &ShapeId) -> Option<&TraitRef> {
+    pub fn get_trait(&self, id: &ShapeId) -> Option<&TraitRef> {
         self.traits().get(id)
     }
 }
@@ -475,7 +475,7 @@ impl<'b> SchemaBuilder<'b> {
 
     /// Adds a trait to the [`SchemaBuilder`]
     #[must_use]
-    pub fn with_trait(mut self, smithy_trait: impl SmithyTrait) -> Self {
+    pub fn with_trait(mut self, smithy_trait: impl Into<TraitRef>) -> Self {
         self.traits.insert(smithy_trait);
         self
     }
@@ -653,7 +653,7 @@ mod tests {
             ShapeId::from("api.smithy#Example"),
             traits![JsonNameTrait::new("other")],
         );
-        assert!(schema.contains_trait_type::<JsonNameTrait>());
+        assert!(schema.contains_type::<JsonNameTrait>());
         let json_name_value = schema
             .get_trait_as::<JsonNameTrait>()
             .expect("No Json Name trait present");
@@ -670,7 +670,7 @@ mod tests {
             .put_member("target_a", &target, traits![])
             .build();
         let member = schema.get_member("target_a").expect("No such member");
-        assert!(member.contains_trait_type::<JsonNameTrait>());
+        assert!(member.contains_type::<JsonNameTrait>());
         let json_name_value = member
             .get_trait_as::<JsonNameTrait>()
             .expect("No JSON name trait present");

--- a/core/src/schema/shapes.rs
+++ b/core/src/schema/shapes.rs
@@ -19,7 +19,7 @@ use crate::schema::SchemaRef;
 /// ```<NAMESPACE>#<NAME>$<MEMBER>```
 ///
 /// The member value is optional.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ShapeId {
     id: String,
     namespace: String,

--- a/core/src/schema/shapes.rs
+++ b/core/src/schema/shapes.rs
@@ -1,3 +1,10 @@
+//! # Shapes
+//! Definition of the [types](https://smithy.io/2.0/spec/simple-types.html) that
+//! compose the Smithy data model.
+//!
+//!
+//!
+
 #![allow(dead_code)]
 
 use std::fmt::Display;
@@ -40,7 +47,7 @@ impl From<&str> for ShapeId {
 
 impl ShapeId {
     /// Creates a shape ID from parts of a shape ID.
-    pub fn from_parts<'a>(namespace: &'a str, name: &'a str, member: Option<&'a str>) -> ShapeId {
+    pub fn from_parts(namespace: &str, name: &str, member: Option<&str>) -> ShapeId {
         let mut id = namespace.to_string() + "#" + name;
         if let Some(m) = member {
             id = id + "$" + m;
@@ -112,6 +119,7 @@ pub enum ShapeType {
     Resource,
     Operation,
 }
+
 impl Display for ShapeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/core/src/schema/traits.rs
+++ b/core/src/schema/traits.rs
@@ -175,7 +175,7 @@ mod tests {
         let Some(cast_value) = map.get_trait_as::<HTTPErrorTrait>() else {
             panic!("Could not find expected trait!!!")
         };
-        assert_eq!(cast_value.code, 404);
+        assert_eq!(cast_value.code(), 404);
         assert_eq!(cast_value.type_id(), TypeId::of::<HTTPErrorTrait>());
     }
 }

--- a/core/src/schema/traits.rs
+++ b/core/src/schema/traits.rs
@@ -40,8 +40,8 @@
 //!
 //!  // Downcast trait to specific impl
 //!  let trait_impl = EXAMPLE_SCHEMA.get_trait_as::<LengthTrait>().unwrap();
-//!  assert_eq!(trait_impl.min, Some(1usize));
-//!  assert_eq!(trait_impl.max, Some(4usize));
+//!  assert_eq!(*trait_impl.min(), Some(1usize));
+//!  assert_eq!(*trait_impl.max(), Some(4usize));
 //! ```
 //!
 //! ## Custom Traits
@@ -74,8 +74,8 @@
 //! Base Smithy Trait implementations such as `@sensitive` and `@default`
 //! can be found in [`crate::schema::prelude`].
 
-use std::{collections::HashMap, fmt::Debug, ops::Deref};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Debug, ops::Deref};
+
 use downcast_rs::{DowncastSync, impl_downcast};
 
 use crate::{

--- a/core/src/schema/traits.rs
+++ b/core/src/schema/traits.rs
@@ -1,4 +1,80 @@
-use std::{collections::HashMap, fmt::Debug};
+//! # Smithy Traits
+//! [Smithy Trait](https://smithy.io/2.0/spec/model.html#traits) definition and
+//! associated utilities.
+//!
+//! ## Using Smithy Traits from as Schema
+//!
+//! Smithy [`crate::schema::Schema`]'s may contain one or more Smithy Traits. These
+//! traits provide structured metadata for the schema and are the primary mechanism to
+//! customize runtime/serde behavior of structures modeled with the schema.
+//!
+//! For example, the [`crate::prelude::JsonNameTrait`] customizes name of a field
+//! when serialized by a JSON protocol.
+//!
+//! Traits on a [`Schema`] can be accessed using the [`Schema::get_trait`] or
+//! [`Schema::get_trait_as`] method.
+//!
+//! Examples of accessing traits from a [`Schema`]:
+//! ```rust
+//! # use std::sync::LazyLock;
+//! # use smithy4rs_core::{lazy_schema, traits, Ref};
+//! # use smithy4rs_core::prelude::{LengthTrait, SensitiveTrait, STRING};
+//! # use smithy4rs_core::schema::{Schema, StaticTraitId, SchemaRef, DocumentValue};
+//!
+//! lazy_schema!(
+//!     EXAMPLE_SCHEMA,
+//!     Schema::create_string("com.example#Map", traits![SensitiveTrait::new(), LengthTrait::builder().max(4).min(1).build()])
+//! );
+//!
+//! /// Checking if a trait is present on a schema
+//!  // Check by ID
+//!  assert!(&EXAMPLE_SCHEMA.contains_trait(&"smithy.api#sensitive".into()));
+//!  // Check by type
+//!  assert!(&EXAMPLE_SCHEMA.contains_type::<SensitiveTrait>());
+//!
+//! /// Accessing trait data from a schema
+//!  // Access as a dynamic trait object.
+//!  let trait_object = EXAMPLE_SCHEMA.get_trait(&"smithy.api#sensitive".into()).unwrap();
+//!  let document_value = trait_object.value();
+//!  assert_eq!(document_value, &DocumentValue::Null);
+//!
+//!  // Downcast trait to specific impl
+//!  let trait_impl = EXAMPLE_SCHEMA.get_trait_as::<LengthTrait>().unwrap();
+//!  assert_eq!(trait_impl.min, Some(1usize));
+//!  assert_eq!(trait_impl.max, Some(4usize));
+//! ```
+//!
+//! ## Custom Traits
+//!
+//! Custom traits on a model are supported automatically with
+//! [`DynamicTrait::from`] method. This maps detected traits into a [`dyn SmithyTrait`]
+//! that can be queried from schemas using their `ShapeId`.
+//!
+//! Example:
+//! ```rust
+//! use smithy4rs_core::schema::{DocumentValue, DynamicTrait, ShapeId};
+//!
+//! // Create a `dyn SmithyTrait` from just the ID and object value.
+//! // This corresponds to a custom trait in the smithy model like:
+//! // use com.example#myCustomTrait
+//! //
+//! // @myCustomTrait(true)
+//! // structure MyStruct { ... }
+//! let custom_trait = DynamicTrait::from("com.example#myCustomTrait".into(), DocumentValue::Boolean(true));
+//! ```
+//!
+//! Custom traits can also have either manually defined or code-generated concrete implementations.
+//! Traits with concrete implementations that implement [`StaticTraitId`] (automatically provided
+//! in code-generated traits) can be downcast into from a Schema.
+//!
+//! As a general rule, if your code needs to check more than just the presence of a
+//! trait it is recommended to create a concrete implementation to make access to the
+//! trait data easier and more structured.
+//!
+//! Base Smithy Trait implementations such as `@sensitive` and `@default`
+//! can be found in [`crate::schema::prelude`].
+
+use std::{collections::HashMap, fmt::Debug, ops::Deref};
 
 use downcast_rs::{DowncastSync, impl_downcast};
 
@@ -24,13 +100,55 @@ pub trait SmithyTrait: DowncastSync {
     fn value(&self) -> &DocumentValue;
 }
 impl_downcast!(sync SmithyTrait);
+impl Debug for dyn SmithyTrait {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "dyn SmithyTrait {{ id: {:?}, value: {:?} }}",
+            self.id(),
+            self.value()
+        )
+    }
+}
 
 /// Pre-defined [`SmithyTrait`] implementations that have a static ID.
 ///
 /// Generated or pre-defined Smithy Traits _should_ implement this trait.
-pub trait StaticTraitId {
+/// [`SmithyTrait`] implementations that do not implement this trait cannot
+/// be downcast into by the [`TraitMap::get_as`] or [`Schema::get_trait_as`]
+/// methods.
+pub trait StaticTraitId: SmithyTrait {
     /// Static trait ID as found in Smithy model definition of the trait.
     fn trait_id() -> &'static ShapeId;
+}
+
+/// Convenience type for cheaply-cloneable reference to a dynamic trait.
+///
+/// This type is a thin wrapper used primarily to allow blanket conversion
+/// implementations.
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct TraitRef(Ref<dyn SmithyTrait>);
+impl PartialEq for TraitRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id() && (self.value() == other.value())
+    }
+}
+impl Deref for TraitRef {
+    type Target = dyn SmithyTrait;
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+impl From<Ref<dyn SmithyTrait>> for TraitRef {
+    fn from(value: Ref<dyn SmithyTrait>) -> Self {
+        Self(value)
+    }
+}
+impl<T: SmithyTrait> From<T> for TraitRef {
+    fn from(value: T) -> Self {
+        Self(Ref::new(value))
+    }
 }
 
 /// Generic Representation of a trait that has no pre-defined rust implementation.
@@ -38,11 +156,25 @@ pub trait StaticTraitId {
 /// This type is used to represent any traits that do not have a corresponding
 /// rust implementation, allowing user-defined traits with no generated
 /// implementation to be read by runtime code.
-#[derive(Debug, Clone)]
+///
+///  In general, users should try to move towards a code-generated versions and downcast
+/// into those if they need to access data within the trait.
+///
+/// NOTE: Dynamic implementations cannot be downcast into a concrete implementation.
+#[derive(Debug, Clone, PartialEq)]
 pub struct DynamicTrait {
     id: ShapeId,
     value: DocumentValue,
 }
+impl DynamicTrait {
+    /// Create a new [`SmithyTrait`] with no corresponding concrete implementation.
+    ///
+    /// NOTE: Traits created with this method cannot be downcast into a specific implementation.
+    pub fn from(id: ShapeId, value: DocumentValue) -> Ref<dyn SmithyTrait> {
+        Ref::new(Self { id, value })
+    }
+}
+
 impl SmithyTrait for DynamicTrait {
     fn id(&self) -> &ShapeId {
         &self.id
@@ -53,16 +185,16 @@ impl SmithyTrait for DynamicTrait {
     }
 }
 
-/// Convenience type for cheaply-cloneable reference to a dynamic trait.
-pub type TraitRef = Ref<dyn SmithyTrait>;
-
-/// Map used to track the traits applied to a shape.
+/// Map used to track the traits applied to a [`Schema`].
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TraitMap {
     map: HashMap<ShapeId, TraitRef>,
 }
 impl TraitMap {
-    /// Creates an empty [`TraitMap`].
+    /// Creates a new, empty [`TraitMap`].
+    ///
+    /// Initially created with 0 capacity so it will not allocate until it
+    /// is first inserted into.
     pub fn new() -> TraitMap {
         TraitMap {
             map: HashMap::new(),
@@ -75,38 +207,39 @@ impl TraitMap {
     ///
     /// If the map did have this key present, the value is updated,
     /// and the previous value is returned.
-    pub fn insert(&mut self, value: impl SmithyTrait) -> Option<TraitRef> {
-        self.map.insert(value.id().clone(), Ref::new(value))
+    pub fn insert(&mut self, value: impl Into<TraitRef>) -> Option<TraitRef> {
+        let trait_ref = value.into();
+        self.map.insert(trait_ref.id().clone(), trait_ref)
     }
 
     /// Returns true if the map contains a value for the specified trait ID.
     #[must_use]
-    pub fn contains_trait(&self, id: &ShapeId) -> bool {
+    pub fn contains(&self, id: &ShapeId) -> bool {
         self.map.contains_key(id)
     }
 
     /// Returns true if the map contains a trait of type `T`.
     #[must_use]
-    pub fn contains_trait_type<T: StaticTraitId>(&self) -> bool {
+    pub fn contains_type<T: StaticTraitId>(&self) -> bool {
         self.map.contains_key(T::trait_id())
     }
 
     /// Returns a reference to the `SmithyTrait` corresponding to the ID.
     ///
     /// If the [`SmithyTrait`] does not exist in the map, then returns `None`.
+    #[must_use]
     pub fn get(&self, id: &ShapeId) -> Option<&TraitRef> {
         self.map.get(id)
     }
 
-    /// Create a new [`TraitMap`] from a vector of [`SmithyTraits`].
+    /// Gets a [`SmithyTrait`] as a specific implementation if it exists.
     ///
-    /// This method is primarily used for constructing shapes.
-    pub fn of(traits: Vec<TraitRef>) -> Self {
-        let mut map: TraitMap = TraitMap::new();
-        for smithy_trait in traits {
-            map.map.insert(smithy_trait.id().clone(), smithy_trait);
-        }
-        map
+    /// If the [`SmithyTrait`] does not exist in the map, returns `None`.
+    #[must_use]
+    pub fn get_as<T: SmithyTrait + StaticTraitId>(&self) -> Option<&T> {
+        self.map
+            .get(T::trait_id())
+            .and_then(|dyn_trait| dyn_trait.downcast_ref::<T>())
     }
 
     /// Extends collection with the contents of another [`TraitMap`].
@@ -114,27 +247,15 @@ impl TraitMap {
         self.map.extend(trait_map.map.clone());
     }
 
-    /// Gets a [`SmithyTrait`] as a specific implementation if it exists.
+    /// Create a new [`TraitMap`] from a vector of [`SmithyTraits`].
     ///
-    /// If the [`SmithyTrait`] does not exist in the map, returns `None`.
-    #[must_use]
-    pub fn get_trait_as<T: SmithyTrait + StaticTraitId>(&self) -> Option<&T> {
-        self.map
-            .get(T::trait_id())
-            .and_then(|dyn_trait| dyn_trait.downcast_ref::<T>())
-    }
-}
-
-impl Debug for dyn SmithyTrait {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        // TODO
-        f.write_str("dyn SmithyTrait")
-    }
-}
-
-impl PartialEq for dyn SmithyTrait {
-    fn eq(&self, other: &Self) -> bool {
-        self.id() == other.id() && (self.value() == other.value())
+    /// This method is primarily used for constructing Schemas.
+    pub(crate) fn of(traits: Vec<TraitRef>) -> Self {
+        let mut map: TraitMap = TraitMap::new();
+        for smithy_trait in traits {
+            map.map.insert(smithy_trait.id().clone(), smithy_trait);
+        }
+        map
     }
 }
 
@@ -143,7 +264,10 @@ mod tests {
     use std::any::{Any, TypeId};
 
     use super::*;
-    use crate::prelude::{HTTPErrorTrait, JsonNameTrait};
+    use crate::{
+        prelude::{HTTPErrorTrait, JsonNameTrait},
+        traits,
+    };
 
     #[test]
     fn basic_map_functionality() {
@@ -154,28 +278,42 @@ mod tests {
             id: dyn_id.clone(),
             value: DocumentValue::String("b".to_string()),
         });
-        assert!(map.contains_trait(&dyn_id));
-        assert!(map.contains_trait(JsonNameTrait::trait_id()));
+        assert!(map.contains(&dyn_id));
+        assert!(map.contains(JsonNameTrait::trait_id()));
+        assert!(map.contains_type::<JsonNameTrait>());
     }
 
     #[test]
     fn map_extension() {
         let mut map_a = TraitMap::new();
         map_a.insert(JsonNameTrait::new("a"));
+
         let mut map_b = TraitMap::new();
         map_b.insert(HTTPErrorTrait::new(404));
+
         map_a.extend(&map_b);
-        assert!(map_a.contains_trait(HTTPErrorTrait::trait_id()));
+        assert!(map_a.contains(HTTPErrorTrait::trait_id()));
+        assert!(map_a.contains_type::<HTTPErrorTrait>());
+        assert!(map_a.contains_type::<JsonNameTrait>());
     }
 
     #[test]
     fn trait_conversion_to_type() {
         let mut map = TraitMap::new();
         map.insert(HTTPErrorTrait::new(404));
-        let Some(cast_value) = map.get_trait_as::<HTTPErrorTrait>() else {
+        let Some(cast_value) = map.get_as::<HTTPErrorTrait>() else {
             panic!("Could not find expected trait!!!")
         };
         assert_eq!(cast_value.code(), 404);
         assert_eq!(cast_value.type_id(), TypeId::of::<HTTPErrorTrait>());
+    }
+
+    #[test]
+    fn from_trait_vec() {
+        let vec = traits![HTTPErrorTrait::new(404), JsonNameTrait::new("a")];
+        let map = TraitMap::of(vec);
+
+        assert!(map.contains_type::<HTTPErrorTrait>());
+        assert!(map.contains_type::<JsonNameTrait>());
     }
 }

--- a/core/src/schema/traits.rs
+++ b/core/src/schema/traits.rs
@@ -75,7 +75,7 @@
 //! can be found in [`crate::schema::prelude`].
 
 use std::{collections::HashMap, fmt::Debug, ops::Deref};
-
+use std::collections::BTreeMap;
 use downcast_rs::{DowncastSync, impl_downcast};
 
 use crate::{
@@ -188,7 +188,9 @@ impl SmithyTrait for DynamicTrait {
 /// Map used to track the traits applied to a [`Schema`].
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TraitMap {
-    map: HashMap<ShapeId, TraitRef>,
+    // NOTE: BTreeMap is used here b/c it outperforms HashMap for access and memory usage
+    //       when the collection size is small. Schemas typically have very few traits.
+    map: BTreeMap<ShapeId, TraitRef>,
 }
 impl TraitMap {
     /// Creates a new, empty [`TraitMap`].
@@ -197,7 +199,7 @@ impl TraitMap {
     /// is first inserted into.
     pub fn new() -> TraitMap {
         TraitMap {
-            map: HashMap::new(),
+            map: BTreeMap::new(),
         }
     }
 

--- a/core/src/serde/fmt.rs
+++ b/core/src/serde/fmt.rs
@@ -20,7 +20,7 @@ use crate::{
 const REDACTED_STRING: &str = "**REDACTED**";
 macro_rules! redact {
     ($self:ident, $schema:ident, $expr:expr) => {
-        if $schema.contains_trait_type::<SensitiveTrait>() {
+        if $schema.contains_type::<SensitiveTrait>() {
             $self
                 .writer
                 .write_all(REDACTED_STRING.as_ref())
@@ -33,7 +33,7 @@ macro_rules! redact {
 
 macro_rules! redact_aggregate {
     ($self:ident, $schema:ident) => {
-        if $schema.contains_trait_type::<SensitiveTrait>() {
+        if $schema.contains_type::<SensitiveTrait>() {
             $self
                 .writer
                 .write_all(REDACTED_STRING.as_ref())
@@ -385,7 +385,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        Ref, lazy_schema,
+        lazy_schema,
         prelude::STRING,
         schema::{Schema, ShapeId},
         traits,


### PR DESCRIPTION
Some touchup/cleanup for the trait module.

I also updated the inner map type for the Traitmap to use a BTreeMap. For small collection sizes BTreeMap should
outperform HashMap and also be more memory efficient. 

I confirmed the improved performance with a microbenchmark checking access time to 10 traits:
```
Std HashMap: 149.83 ns/iter (+/- 6.08)
BTreeMap: 56.45 ns/iter (+/- 0.51)
HashMap with `Fx` hasher: 60.05 ns/iter (+/- 0.49)
```
