### PR TITLE
Switch to mise for build

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,0 +1,40 @@
+[tools]
+# We need cargo-binstall so that Mise would download "cargo:" tools instead of building them.
+"cargo-binstall" = "latest"
+"cargo:cargo-nextest" = "latest"
+"cargo:cargo-deny" = "latest"
+rust = "1.90.0"
+
+[tasks.build]
+description = "Build the project"
+run = "cargo build"
+
+[tasks.fmt-all]
+wait_for = ["build", "lint", "test"]
+description = "Check the code format"
+run = "cargo +nightly fmt --all --"
+
+[tasks.lint]
+wait_for = ["test"]
+depends = ["build"]
+description = "Lint the code with Clippy"
+env = { RUST_BACKTRACE = '1' }
+run = "cargo clippy --workspace --all-targets"
+
+[tasks.audit]
+wait_for = ["build", "lint", "test", "fmt-all"]
+description = "Audit Dependencies"
+run = "cargo deny check"
+
+[tasks.test]
+wait_for = ["build"]
+description = "Tests the library"
+run = "cargo nextest run --locked"
+
+[tasks.clean]
+description = "Remove build artifacts"
+run = "cargo clean"
+
+[tasks.pre-push]
+description = "Check that project will pass CI checks"
+depends = ['build', 'lint', 'audit', 'test', 'fmt-all']

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -3,7 +3,7 @@
 "cargo-binstall" = "latest"
 "cargo:cargo-nextest" = "latest"
 "cargo:cargo-deny" = "latest"
-rust = "1.90.0"
+rust = { version = "1.90.0", components="clippy,rustfmt" }
 
 [tasks.build]
 description = "Build the project"

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -22,7 +22,8 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --locked --all-features
+      - uses: jdx/mise-action@v2
+      - run: mise build
 
   tests:
     name: Tests
@@ -35,11 +36,14 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --locked --all-features
+      - uses: jdx/mise-action@v2
+      - run: mise test
 
-  clippy:
-    name: Clippy
+  lint:
+    name: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -51,7 +55,8 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --locked --all-features --all-targets
+      - uses: jdx/mise-action@v2
+      - run: mise lint
 
   formatting:
     name: Formatting
@@ -65,7 +70,21 @@ jobs:
           toolchain: nightly
           override: 'true'
           components: rustfmt
-      - run: cargo +nightly fmt --all -- --check
+      - uses: jdx/mise-action@v2
+      - run: mise fmt-all --check
+
+  dependencies:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: jdx/mise-action@v2
+      - run: mise audit
 
   spell-check:
     name: Spell Check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ version = "0.0.1"
 edition = "2024"
 repository = "https://github.com/mellemahp/smithy4rs"
 license-file = "LICENSE"
+license = "Apache-2.0"
 readme = "README.md"
 authors = ["Hunter Mellema <hunter@hmellema.space>"]
 keywords = ["smithy", "api"]
@@ -46,6 +47,15 @@ regex = "1.11.2"
 [workspace.lints.rust]
 future-incompatible = "warn"
 nonstandard_style = { level = "deny", priority = 1 }
+unsafe_code = "forbid"
+unused_qualifications = "warn"
+unused_extern_crates = "forbid"
+unreachable_code = "forbid"
+unreachable_patterns = "forbid"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+elided_lifetimes_in_paths = "warn"
+# missing_docs = { level = "deny" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = 10 }
@@ -58,3 +68,6 @@ manual_ok_or = { level = "deny" }
 manual_while_let_some = { level = "deny" }
 unnecessary_wraps = { level = "deny" }
 needless_collect = { level = "deny" }
+# documentation lints
+doc_link_with_quotes = { level = "deny" }
+doc_markdown = { level = "deny" }

--- a/core-derive/Cargo.toml
+++ b/core-derive/Cargo.toml
@@ -7,7 +7,7 @@ readme.workspace = true
 authors.workspace = true
 keywords.workspace = true
 categories.workspace = true
-license-file.workspace = true
+license.workspace = true
 edition.workspace = true
 version.workspace = true
 

--- a/core-derive/src/lib.rs
+++ b/core-derive/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate proc_macro;
 use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ readme.workspace = true
 authors.workspace = true
 keywords.workspace = true
 categories.workspace = true
-license-file.workspace = true
+license.workspace = true
 edition.workspace = true
 version.workspace = true
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 pub mod schema;
 
 pub use schema::prelude;

--- a/core/src/schema/documents.rs
+++ b/core/src/schema/documents.rs
@@ -185,7 +185,7 @@ pub(crate) fn get_shape_type(schema: &Schema) -> Result<&ShapeType, Box<dyn Erro
 }
 
 pub(crate) fn conversion_error(expected: &'static str) -> Box<dyn Error> {
-    Box::new(DocumentError::DocumentConversion(expected.to_string())) as Box<dyn Error>
+    Box::new(DocumentError::DocumentConversion(expected.to_string()))
 }
 
 //////////////////////////////////////////////////////////////////

--- a/core/src/serde/adapter.rs
+++ b/core/src/serde/adapter.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Formatter},

--- a/core/src/serde/serializers.rs
+++ b/core/src/serde/serializers.rs
@@ -134,7 +134,7 @@ pub trait StructSerializer {
     fn end(self, schema: &SchemaRef) -> Result<Self::Ok, Self::Error>;
 }
 
-/// Basically just a clone of the serde::Error trait.
+/// Basically just a clone of the `serde::Error` trait.
 /// We use our own to ensure we don't enforce a `serde` dependency on consumers.
 pub trait Error: Sized + StdError {
     fn custom<T: Display>(msg: T) -> Self;

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,110 @@
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for unmaintained crates
+unmaintained = "workspace"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+git-fetch-with-cli = true
+
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+
+# rustsec advisory exemptions
+ignore = []
+
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "Unicode-3.0",
+    "BSD-3-Clause"
+]
+
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+

--- a/json-codec/Cargo.toml
+++ b/json-codec/Cargo.toml
@@ -7,7 +7,7 @@ readme.workspace = true
 authors.workspace = true
 keywords.workspace = true
 categories.workspace = true
-license-file.workspace = true
+license.workspace = true
 edition.workspace = true
 version.workspace = true
 


### PR DESCRIPTION
Switches to mise for the root build tool. This will be particularly helpful once we are mixing java and rust in the repo.