### PR TITLE
Add prefix for generated member fields

### DIFF
--- a/core-derive/tests/expand/simple_struct.expanded.rs
+++ b/core-derive/tests/expand/simple_struct.expanded.rs
@@ -5,11 +5,11 @@ use smithy4rs_core::{
 use smithy4rs_core_derive::SmithyStruct;
 #[smithy_schema(SIMPLE_SCHEMA)]
 pub struct SimpleStruct {
-    #[smithy_schema(FIELD_A)]
+    #[smithy_schema(A)]
     pub field_a: String,
-    #[smithy_schema(FIELD_B)]
+    #[smithy_schema(B)]
     pub field_b: i32,
-    #[smithy_schema(FIELD_C)]
+    #[smithy_schema(C)]
     pub field_c: Option<Nested>,
 }
 const _: () = {
@@ -37,9 +37,21 @@ const _: () = {
             serializer: S,
         ) -> Result<S::Ok, S::Error> {
             let mut ser = serializer.write_struct(schema, 3usize)?;
-            ser.serialize_member_named("field_a", &FIELD_A, &self.field_a)?;
-            ser.serialize_member_named("field_b", &FIELD_B, &self.field_b)?;
-            ser.serialize_optional_member_named("field_c", &FIELD_C, &self.field_c)?;
+            ser.serialize_member_named(
+                "field_a",
+                &_SIMPLE_SCHEMA_MEMBER_A,
+                &self.field_a,
+            )?;
+            ser.serialize_member_named(
+                "field_b",
+                &_SIMPLE_SCHEMA_MEMBER_B,
+                &self.field_b,
+            )?;
+            ser.serialize_optional_member_named(
+                "field_c",
+                &_SIMPLE_SCHEMA_MEMBER_C,
+                &self.field_c,
+            )?;
             ser.end(schema)
         }
     }
@@ -132,9 +144,21 @@ const _: () = {
             serializer: S,
         ) -> Result<S::Ok, S::Error> {
             let mut ser = serializer.write_struct(schema, 3usize)?;
-            ser.serialize_member_named("field_a", &FIELD_A, &self.field_a)?;
-            ser.serialize_member_named("field_b", &FIELD_B, &self.field_b)?;
-            ser.serialize_optional_member_named("field_c", &FIELD_C, &self.field_c)?;
+            ser.serialize_member_named(
+                "field_a",
+                &_SIMPLE_SCHEMA_MEMBER_A,
+                &self.field_a,
+            )?;
+            ser.serialize_member_named(
+                "field_b",
+                &_SIMPLE_SCHEMA_MEMBER_B,
+                &self.field_b,
+            )?;
+            ser.serialize_optional_member_named(
+                "field_c",
+                &_SIMPLE_SCHEMA_MEMBER_C,
+                &self.field_c,
+            )?;
             ser.end(schema)
         }
     }
@@ -153,21 +177,30 @@ const _: () = {
                     schema,
                     builder,
                     |builder, member_schema, de| {
-                        if std::sync::Arc::ptr_eq(member_schema, &FIELD_A) {
+                        if std::sync::Arc::ptr_eq(
+                            member_schema,
+                            &_SIMPLE_SCHEMA_MEMBER_A,
+                        ) {
                             let value = <String as ::smithy4rs_core::serde::deserializers::DeserializeWithSchema>::deserialize_with_schema(
                                 member_schema,
                                 de,
                             )?;
                             return Ok(builder.field_a(value));
                         }
-                        if std::sync::Arc::ptr_eq(member_schema, &FIELD_B) {
+                        if std::sync::Arc::ptr_eq(
+                            member_schema,
+                            &_SIMPLE_SCHEMA_MEMBER_B,
+                        ) {
                             let value = <i32 as ::smithy4rs_core::serde::deserializers::DeserializeWithSchema>::deserialize_with_schema(
                                 member_schema,
                                 de,
                             )?;
                             return Ok(builder.field_b(value));
                         }
-                        if std::sync::Arc::ptr_eq(member_schema, &FIELD_C) {
+                        if std::sync::Arc::ptr_eq(
+                            member_schema,
+                            &_SIMPLE_SCHEMA_MEMBER_C,
+                        ) {
                             let value = <Option<
                                 NestedBuilder,
                             > as ::smithy4rs_core::serde::deserializers::DeserializeWithSchema>::deserialize_with_schema(
@@ -214,7 +247,7 @@ impl ::core::cmp::PartialEq for SimpleStruct {
 }
 #[smithy_schema(NESTED_SCHEMA)]
 pub struct Nested {
-    #[smithy_schema(FIELD_C)]
+    #[smithy_schema(D)]
     pub field_a: String,
 }
 const _: () = {
@@ -242,7 +275,11 @@ const _: () = {
             serializer: S,
         ) -> Result<S::Ok, S::Error> {
             let mut ser = serializer.write_struct(schema, 1usize)?;
-            ser.serialize_member_named("field_a", &FIELD_C, &self.field_a)?;
+            ser.serialize_member_named(
+                "field_a",
+                &_NESTED_SCHEMA_MEMBER_D,
+                &self.field_a,
+            )?;
             ser.end(schema)
         }
     }
@@ -315,7 +352,11 @@ const _: () = {
             serializer: S,
         ) -> Result<S::Ok, S::Error> {
             let mut ser = serializer.write_struct(schema, 1usize)?;
-            ser.serialize_member_named("field_a", &FIELD_C, &self.field_a)?;
+            ser.serialize_member_named(
+                "field_a",
+                &_NESTED_SCHEMA_MEMBER_D,
+                &self.field_a,
+            )?;
             ser.end(schema)
         }
     }
@@ -334,7 +375,10 @@ const _: () = {
                     schema,
                     builder,
                     |builder, member_schema, de| {
-                        if std::sync::Arc::ptr_eq(member_schema, &FIELD_C) {
+                        if std::sync::Arc::ptr_eq(
+                            member_schema,
+                            &_NESTED_SCHEMA_MEMBER_D,
+                        ) {
                             let value = <String as ::smithy4rs_core::serde::deserializers::DeserializeWithSchema>::deserialize_with_schema(
                                 member_schema,
                                 de,

--- a/core-derive/tests/expand/simple_struct.rs
+++ b/core-derive/tests/expand/simple_struct.rs
@@ -16,23 +16,23 @@ smithy!("test#SimpleStruct": {
 #[derive(SmithyStruct, Debug, PartialEq)]
 #[smithy_schema(SIMPLE_SCHEMA)]
 pub struct SimpleStruct {
-    #[smithy_schema(FIELD_A)]
+    #[smithy_schema(A)]
     pub field_a: String,
-    #[smithy_schema(FIELD_B)]
+    #[smithy_schema(B)]
     pub field_b: i32,
-    #[smithy_schema(FIELD_C)]
+    #[smithy_schema(C)]
     pub field_c: Option<Nested>,
 }
 
 smithy!("test#NESTED_STRUCT": {
     structure NESTED_SCHEMA {
-        FIELD_D: STRING = "field_d"
+        D: STRING = "field_d"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq)]
 #[smithy_schema(NESTED_SCHEMA)]
 pub struct Nested {
-    #[smithy_schema(FIELD_C)]
+    #[smithy_schema(D)]
     pub field_a: String,
 }

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -19,39 +19,38 @@ use smithy4rs_core_derive::SmithyStruct;
 smithy!("test#ValidationStruct": {
     structure VALIDATE_SHAPE_SCHEMA {
         @LengthTrait::builder().min(1).max(100).build();
-        FIELD_STRING: STRING = "string"
+        STRING: STRING = "string"
         @RangeTrait::builder().max(BigDecimal::from(100)).build();
-        FIELD_REQUIRED_INT: INTEGER = "required_int"
-        FIELD_INTEGER: INTEGER = "integer"
+        REQUIRED_INT: INTEGER = "required_int"
+        INTEGER: INTEGER = "integer"
     }
 });
-
 #[derive(SmithyStruct, Clone)]
 #[smithy_schema(VALIDATE_SHAPE_SCHEMA)]
 pub struct ValidatedStruct {
-    #[smithy_schema(FIELD_STRING)]
+    #[smithy_schema(STRING)]
     string: String,
-    #[smithy_schema(FIELD_REQUIRED_INT)]
+    #[smithy_schema(REQUIRED_INT)]
     required_int: i32,
-    #[smithy_schema(FIELD_INTEGER)]
+    #[smithy_schema(INTEGER)]
     integer: Option<i32>,
 }
 
 smithy!("test#UnvalidatedShape": {
     structure UNVALIDATED_SHAPE_SCHEMA {
-        FIELD_UNCHECKED_STRING: STRING = "string"
-        FIELD_UNCHECKED_REQUIRED_INT: INTEGER = "required_int"
-        FIELD_UNCHECKED_INT: INTEGER = "integer"
+        STRING: STRING = "string"
+        REQUIRED_INT: INTEGER = "required_int"
+        INT: INTEGER = "integer"
     }
 });
 #[derive(SmithyStruct, Clone)]
 #[smithy_schema(UNVALIDATED_SHAPE_SCHEMA)]
 pub struct UnvalidatedStruct {
-    #[smithy_schema(FIELD_UNCHECKED_STRING)]
+    #[smithy_schema(STRING)]
     string: String,
-    #[smithy_schema(FIELD_REQUIRED_INT)]
+    #[smithy_schema(REQUIRED_INT)]
     required_int: i32,
-    #[smithy_schema(FIELD_UNCHECKED_INT)]
+    #[smithy_schema(INT)]
     integer: Option<i32>,
 }
 
@@ -69,37 +68,37 @@ smithy!("com.example#MapOfNested": {
 
 smithy!("test#StructWithNestedList": {
     structure STRUCT_WITH_COLLECTIONS {
-        FIELD_NESTED_LIST: LIST_OF_NESTED_SCHEMA = "field_nested_list"
-        FIELD_NESTED_MAP: MAP_OF_NESTED_SCHEMA = "field_nested_map"
+        LIST: LIST_OF_NESTED_SCHEMA = "field_nested_list"
+        MAP: MAP_OF_NESTED_SCHEMA = "field_nested_map"
     }
 });
 
 #[derive(SmithyStruct, Clone)]
 #[smithy_schema(STRUCT_WITH_COLLECTIONS)]
 pub struct StructWithCollections {
-    #[smithy_schema(FIELD_NESTED_LIST)]
+    #[smithy_schema(LIST)]
     field_nested_list: Option<Vec<ValidatedStruct>>,
-    #[smithy_schema(FIELD_NESTED_MAP)]
+    #[smithy_schema(MAP)]
     field_nested_map: Option<IndexMap<String, ValidatedStruct>>,
 }
 
 smithy!("test#StructWithNestedSet": {
     structure STRUCT_WITH_SET {
         @UniqueItemsTrait;
-        FIELD_NESTED_SET: LIST_OF_NESTED_SCHEMA = "field_nested_set"
+        NESTED_SET: LIST_OF_NESTED_SCHEMA = "field_nested_set"
     }
 });
 
 #[derive(SmithyStruct, Clone)]
 #[smithy_schema(STRUCT_WITH_SET)]
 pub struct StructWithSet {
-    #[smithy_schema(FIELD_NESTED_SET)]
+    #[smithy_schema(NESTED_SET)]
     field_nested_set: Option<Vec<ValidatedStruct>>,
 }
 
 smithy!("test#StructWithNestedList": {
     structure STRUCT_WITH_LIST {
-        FIELD_WITH_NESTED_LIST: LIST_OF_NESTED_SCHEMA = "field_nested_list"
+        NESTED_LIST: LIST_OF_NESTED_SCHEMA = "field_nested_list"
     }
 });
 
@@ -107,7 +106,7 @@ smithy!("test#StructWithNestedList": {
 #[derive(SmithyStruct, Clone)]
 #[smithy_schema(STRUCT_WITH_LIST)]
 pub struct StructWithList {
-    #[smithy_schema(FIELD_WITH_NESTED_LIST)]
+    #[smithy_schema(NESTED_LIST)]
     field_nested_list: Option<Vec<ValidatedStruct>>,
 }
 

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -272,7 +272,7 @@ macro_rules! smithy_internal {
                 $crate::smithy!(@build_chain (&*[<$schema_name _BUILDER>]), &*[<$schema_name _BUILDER>] $(, ($member_ident, $member_schema, $member_traits))*)
             });
 
-            $(pub static $member_schema_name: $crate::LazyLock<&$crate::schema::SchemaRef> =
+            $(pub static [<_$schema_name _MEMBER_$member_schema_name>]: $crate::LazyLock<&$crate::schema::SchemaRef> =
                 $crate::LazyLock::new(|| $schema_name.expect_member($member_ident));
             )*
         }

--- a/core/src/serde/adapter.rs
+++ b/core/src/serde/adapter.rs
@@ -286,7 +286,7 @@ impl<T: SerializeWithSchema + ?Sized> serde::Serialize for ValueWrapper<'_, T> {
 #[cfg(test)]
 mod tests {
     use indexmap::IndexMap;
-    use smithy4rs_core_derive::{SchemaShape, SerializableStruct};
+    use smithy4rs_core_derive::SmithyStruct;
 
     use super::*;
     use crate::{prelude::*, schema::SchemaShape, smithy};
@@ -304,23 +304,23 @@ mod tests {
     });
     smithy!("com.example#Test": {
         structure SCHEMA {
-            MEMBER_A: STRING = "a"
-            MEMBER_B: STRING = "b"
-            MEMBER_MAP: MAP_SCHEMA = "map"
-            MEMBER_LIST: LIST_SCHEMA = "list"
+            A: STRING = "a"
+            B: STRING = "b"
+            MAP: MAP_SCHEMA = "map"
+            LIST: LIST_SCHEMA = "list"
         }
     });
 
-    #[derive(SchemaShape, SerializableStruct)]
+    #[derive(SmithyStruct)]
     #[smithy_schema(SCHEMA)]
-    struct Test {
-        #[smithy_schema(MEMBER_A)]
+    pub struct Test {
+        #[smithy_schema(A)]
         a: String,
-        #[smithy_schema(MEMBER_B)]
+        #[smithy_schema(B)]
         b: String,
-        #[smithy_schema(MEMBER_LIST)]
+        #[smithy_schema(LIST)]
         member_list: Vec<String>,
-        #[smithy_schema(MEMBER_MAP)]
+        #[smithy_schema(MAP)]
         member_map: IndexMap<String, String>,
     }
 

--- a/core/src/serde/documents.rs
+++ b/core/src/serde/documents.rs
@@ -763,26 +763,26 @@ mod tests {
     });
     smithy!("com.example#Shape": {
         structure SCHEMA {
-            MEMBER_A: STRING = "a"
-            MEMBER_B: STRING = "b"
-            MEMBER_C: STRING = "c"
-            MEMBER_LIST: LIST_SCHEMA = "list"
-            MEMBER_MAP: MAP_SCHEMA = "map"
+            A: STRING = "a"
+            B: STRING = "b"
+            C: STRING = "c"
+            LIST: LIST_SCHEMA = "list"
+            MAP: MAP_SCHEMA = "map"
         }
     });
 
     #[derive(SmithyStruct)]
     #[smithy_schema(SCHEMA)]
     pub struct SerializeMe {
-        #[smithy_schema(MEMBER_A)]
+        #[smithy_schema(A)]
         pub member_a: String,
-        #[smithy_schema(MEMBER_B)]
+        #[smithy_schema(B)]
         pub member_b: String,
-        #[smithy_schema(MEMBER_C)]
+        #[smithy_schema(C)]
         pub member_optional: Option<String>,
-        #[smithy_schema(MEMBER_LIST)]
+        #[smithy_schema(LIST)]
         pub member_list: Vec<String>,
-        #[smithy_schema(MEMBER_MAP)]
+        #[smithy_schema(MAP)]
         pub member_map: IndexMap<String, String>,
     }
 

--- a/core/src/serde/fmt.rs
+++ b/core/src/serde/fmt.rs
@@ -404,44 +404,44 @@ mod tests {
     });
     smithy!("com.example#Shape": {
         structure SCHEMA {
-            MEMBER_A: STRING = "a"
+            A: STRING = "a"
             @SensitiveTrait;
-            MEMBER_B: STRING = "b"
-            MEMBER_C: STRING = "c"
-            MEMBER_MAP: MAP_SCHEMA = "map"
-            MEMBER_LIST: LIST_SCHEMA = "list"
+            B: STRING = "b"
+            C: STRING = "c"
+            MAP: MAP_SCHEMA = "map"
+            LIST: LIST_SCHEMA = "list"
         }
     });
     smithy!("com.example#Shape": {
         structure REDACTED_AGGREGATES {
             @SensitiveTrait;
-            MEMBER_MAP_REDACT: MAP_SCHEMA = "map"
+            MAP_REDACT: MAP_SCHEMA = "map"
             @SensitiveTrait;
-            MEMBER_LIST_REDACT: LIST_SCHEMA = "list"
+            LIST_REDACT: LIST_SCHEMA = "list"
         }
     });
 
     #[derive(SchemaShape, SerializableStruct)]
     #[smithy_schema(SCHEMA)]
     pub struct SerializeMe {
-        #[smithy_schema(MEMBER_A)]
+        #[smithy_schema(A)]
         pub member_a: String,
-        #[smithy_schema(MEMBER_B)]
+        #[smithy_schema(B)]
         pub member_b: String,
-        #[smithy_schema(MEMBER_C)]
+        #[smithy_schema(C)]
         pub member_optional: Option<String>,
-        #[smithy_schema(MEMBER_LIST)]
+        #[smithy_schema(LIST)]
         pub member_list: Vec<String>,
-        #[smithy_schema(MEMBER_MAP)]
+        #[smithy_schema(MAP)]
         pub member_map: IndexMap<String, String>,
     }
 
     #[derive(SchemaShape, SerializableStruct)]
     #[smithy_schema(REDACTED_AGGREGATES)]
     pub(crate) struct RedactMe {
-        #[smithy_schema(MEMBER_LIST_REDACT)]
+        #[smithy_schema(LIST_REDACT)]
         pub member_list: Vec<String>,
-        #[smithy_schema(MEMBER_MAP_REDACT)]
+        #[smithy_schema(MAP_REDACT)]
         pub member_map: IndexMap<String, String>,
     }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -28,147 +28,147 @@ smithy!("test#IntegerList": {
 
 smithy!("test#AllPrimitivesStruct": {
     structure ALL_PRIMITIVES_STRUCT_SCHEMA {
-        ALL_PRIMITIVES_STRING: STRING = "string_field"
-        ALL_PRIMITIVES_BYTE: BYTE = "byte_field"
-        ALL_PRIMITIVES_SHORT: SHORT = "short_field"
-        ALL_PRIMITIVES_INTEGER: INTEGER = "integer_field"
-        ALL_PRIMITIVES_LONG: LONG = "long_field"
-        ALL_PRIMITIVES_FLOAT: FLOAT = "float_field"
-        ALL_PRIMITIVES_DOUBLE: DOUBLE = "double_field"
-        ALL_PRIMITIVES_BOOLEAN: BOOLEAN = "boolean_field"
-        ALL_PRIMITIVES_BLOB: BLOB = "blob_field"
-        ALL_PRIMITIVES_TIMESTAMP: TIMESTAMP = "timestamp_field"
+        STRING: STRING = "string_field"
+        BYTE: BYTE = "byte_field"
+        SHORT: SHORT = "short_field"
+        INTEGER: INTEGER = "integer_field"
+        LONG: LONG = "long_field"
+        FLOAT: FLOAT = "float_field"
+        DOUBLE: DOUBLE = "double_field"
+        BOOLEAN: BOOLEAN = "boolean_field"
+        BLOB: BLOB = "blob_field"
+        TIMESTAMP: TIMESTAMP = "timestamp_field"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(ALL_PRIMITIVES_STRUCT_SCHEMA)]
 pub struct AllPrimitivesStruct {
-    #[smithy_schema(ALL_PRIMITIVES_STRING)]
+    #[smithy_schema(STRING)]
     pub string_field: String,
-    #[smithy_schema(ALL_PRIMITIVES_BYTE)]
+    #[smithy_schema(BYTE)]
     pub byte_field: i8,
-    #[smithy_schema(ALL_PRIMITIVES_SHORT)]
+    #[smithy_schema(SHORT)]
     pub short_field: i16,
-    #[smithy_schema(ALL_PRIMITIVES_INTEGER)]
+    #[smithy_schema(INTEGER)]
     pub integer_field: i32,
-    #[smithy_schema(ALL_PRIMITIVES_LONG)]
+    #[smithy_schema(LONG)]
     pub long_field: i64,
-    #[smithy_schema(ALL_PRIMITIVES_FLOAT)]
+    #[smithy_schema(FLOAT)]
     pub float_field: f32,
-    #[smithy_schema(ALL_PRIMITIVES_DOUBLE)]
+    #[smithy_schema(DOUBLE)]
     pub double_field: f64,
-    #[smithy_schema(ALL_PRIMITIVES_BOOLEAN)]
+    #[smithy_schema(BOOLEAN)]
     pub boolean_field: bool,
-    #[smithy_schema(ALL_PRIMITIVES_BLOB)]
+    #[smithy_schema(BLOB)]
     pub blob_field: ByteBuffer,
-    #[smithy_schema(ALL_PRIMITIVES_TIMESTAMP)]
+    #[smithy_schema(TIMESTAMP)]
     pub timestamp_field: Instant,
 }
 
 smithy!("test#OptionalFieldsStruct": {
     structure OPTIONAL_FIELDS_STRUCT_SCHEMA {
-        OPTIONAL_REQUIRED: STRING = "required_field"
-        OPTIONAL_OPTIONAL: STRING = "optional_field"
+        REQUIRED: STRING = "required_field"
+        OPTIONAL: STRING = "optional_field"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(OPTIONAL_FIELDS_STRUCT_SCHEMA)]
 pub struct OptionalFieldsStruct {
-    #[smithy_schema(OPTIONAL_REQUIRED)]
+    #[smithy_schema(REQUIRED)]
     pub required_field: String,
-    #[smithy_schema(OPTIONAL_OPTIONAL)]
+    #[smithy_schema(OPTIONAL)]
     pub optional_field: Option<String>,
 }
 
 smithy!("test#NumericTypesStruct": {
     structure NUMERIC_TYPES_STRUCT_SCHEMA {
-        NUMERIC_BYTE: BYTE = "byte_val"
-        NUMERIC_SHORT: SHORT = "short_val"
-        NUMERIC_INT: INTEGER = "int_val"
-        NUMERIC_LONG: LONG = "long_val"
-        NUMERIC_FLOAT: FLOAT = "float_val"
-        NUMERIC_DOUBLE: DOUBLE = "double_val"
+        BYTE: BYTE = "byte_val"
+        SHORT: SHORT = "short_val"
+        INT: INTEGER = "int_val"
+        LONG: LONG = "long_val"
+        FLOAT: FLOAT = "float_val"
+        DOUBLE: DOUBLE = "double_val"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(NUMERIC_TYPES_STRUCT_SCHEMA)]
 pub struct NumericTypesStruct {
-    #[smithy_schema(NUMERIC_BYTE)]
+    #[smithy_schema(BYTE)]
     pub byte_val: i8,
-    #[smithy_schema(NUMERIC_SHORT)]
+    #[smithy_schema(SHORT)]
     pub short_val: i16,
-    #[smithy_schema(NUMERIC_INT)]
+    #[smithy_schema(INT)]
     pub int_val: i32,
-    #[smithy_schema(NUMERIC_LONG)]
+    #[smithy_schema(LONG)]
     pub long_val: i64,
-    #[smithy_schema(NUMERIC_FLOAT)]
+    #[smithy_schema(FLOAT)]
     pub float_val: f32,
-    #[smithy_schema(NUMERIC_DOUBLE)]
+    #[smithy_schema(DOUBLE)]
     pub double_val: f64,
 }
 
 smithy!("test#SimpleStruct": {
     structure SIMPLE_STRUCT_SCHEMA {
-        SIMPLE_FIELD_A: STRING = "field_a"
-        SIMPLE_FIELD_B: INTEGER = "field_b"
+        A: STRING = "field_a"
+        B: INTEGER = "field_b"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(SIMPLE_STRUCT_SCHEMA)]
 pub struct SimpleStruct {
-    #[smithy_schema(SIMPLE_FIELD_A)]
+    #[smithy_schema(A)]
     pub field_a: String,
-    #[smithy_schema(SIMPLE_FIELD_B)]
+    #[smithy_schema(B)]
     pub field_b: i32,
 }
 
 smithy!("test#RecursiveShapesStruct": {
     structure RECURSIVE_SHAPES_STRUCT_SCHEMA {
-        RECURSIVE_SHAPES_STRING: STRING = "string_field"
-        RECURSIVE_SHAPES_INTEGER: INTEGER = "integer_field"
-        RECURSIVE_SHAPES_LIST: STRING_LIST_SCHEMA = "list_field"
-        RECURSIVE_SHAPES_MAP: STRING_MAP_SCHEMA = "map_field"
-        RECURSIVE_SHAPES_OPTIONAL: STRING = "optional_field"
-        RECURSIVE_SHAPES_NEXT: (@self) = "next"
+        STRING: STRING = "string_field"
+        INTEGER: INTEGER = "integer_field"
+        LIST: STRING_LIST_SCHEMA = "list_field"
+        MAP: STRING_MAP_SCHEMA = "map_field"
+        OPTIONAL: STRING = "optional_field"
+        NEXT: (@self) = "next"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(RECURSIVE_SHAPES_STRUCT_SCHEMA)]
 pub struct RecursiveShapesStruct {
-    #[smithy_schema(RECURSIVE_SHAPES_STRING)]
+    #[smithy_schema(STRING)]
     pub string_field: String,
-    #[smithy_schema(RECURSIVE_SHAPES_INTEGER)]
+    #[smithy_schema(INTEGER)]
     pub integer_field: i32,
-    #[smithy_schema(RECURSIVE_SHAPES_LIST)]
+    #[smithy_schema(LIST)]
     pub list_field: Vec<String>,
-    #[smithy_schema(RECURSIVE_SHAPES_MAP)]
+    #[smithy_schema(MAP)]
     pub map_field: IndexMap<String, String>,
-    #[smithy_schema(RECURSIVE_SHAPES_OPTIONAL)]
+    #[smithy_schema(OPTIONAL)]
     pub optional_field: Option<String>,
-    #[smithy_schema(RECURSIVE_SHAPES_NEXT)]
+    #[smithy_schema(NEXT)]
     pub next: Option<Box<RecursiveShapesStruct>>,
 }
 smithy!("test#InnerStruct": {
     structure INNER_STRUCT_SCHEMA {
-        INNER_FIELD_A: STRING = "field_a"
-        INNER_FIELD_B: STRING = "field_b"
-        INNER_FIELD_C: STRING = "field_c"
+        A: STRING = "field_a"
+        B: STRING = "field_b"
+        C: STRING = "field_c"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(INNER_STRUCT_SCHEMA)]
 pub struct InnerStruct {
-    #[smithy_schema(INNER_FIELD_A)]
+    #[smithy_schema(A)]
     pub field_a: String,
-    #[smithy_schema(INNER_FIELD_B)]
+    #[smithy_schema(B)]
     pub field_b: String,
-    #[smithy_schema(INNER_FIELD_C)]
+    #[smithy_schema(C)]
     pub field_c: String,
 }
 
@@ -185,28 +185,28 @@ smithy!("test#InnerStructMap": {
 });
 smithy!("test#NestedCollectionsStruct": {
     structure NESTED_COLLECTIONS_STRUCT_SCHEMA {
-        NESTED_NAME: STRING = "name"
-        NESTED_COUNT: INTEGER = "count"
-        NESTED_SINGLE: INNER_STRUCT_SCHEMA = "single_nested"
-        NESTED_OPTIONAL: INNER_STRUCT_SCHEMA = "optional_nested"
-        NESTED_LIST: INNER_STRUCT_LIST_SCHEMA = "list_nested"
-        NESTED_MAP: INNER_STRUCT_MAP_SCHEMA = "map_nested"
+        NAME: STRING = "name"
+        COUNT: INTEGER = "count"
+        SINGLE: INNER_STRUCT_SCHEMA = "single_nested"
+        OPTIONAL: INNER_STRUCT_SCHEMA = "optional_nested"
+        LIST: INNER_STRUCT_LIST_SCHEMA = "list_nested"
+        MAP: INNER_STRUCT_MAP_SCHEMA = "map_nested"
     }
 });
 
 #[derive(SmithyStruct, Debug, PartialEq, Clone)]
 #[smithy_schema(NESTED_COLLECTIONS_STRUCT_SCHEMA)]
 pub struct NestedCollectionsStruct {
-    #[smithy_schema(NESTED_NAME)]
+    #[smithy_schema(NAME)]
     pub name: String,
-    #[smithy_schema(NESTED_COUNT)]
+    #[smithy_schema(COUNT)]
     pub count: i32,
-    #[smithy_schema(NESTED_SINGLE)]
+    #[smithy_schema(SINGLE)]
     pub single_nested: InnerStruct,
-    #[smithy_schema(NESTED_OPTIONAL)]
+    #[smithy_schema(OPTIONAL)]
     pub optional_nested: Option<InnerStruct>,
-    #[smithy_schema(NESTED_LIST)]
+    #[smithy_schema(LIST)]
     pub list_nested: Vec<InnerStruct>,
-    #[smithy_schema(NESTED_MAP)]
+    #[smithy_schema(MAP)]
     pub map_nested: IndexMap<String, InnerStruct>,
 }


### PR DESCRIPTION
Adds member prefixing such that generate static member fields are named:
`_<PARENT_SCHEMA_IDENTIFIER>_MEMBER_<MEMBER_IDENTIFIER>`

This achieves a few things: 
1. Allows users to pick simple member identifiers within a schema macro without needing to add some prefix
2. Ensures that generated member identifiers are unique. 
3. Underscores member identifiers to indicated that they are "private-ish" (i.e. shouldn't really be used directly) 

### Example
The following macro invocation:
```rust
smithy!("test#Struct": {
    structure SCHEMA {
        A: STRING = "field_a"
    }
});
```

Expands to: 
```rust
pub static SCHEMA_BUILDER: ::smithy4rs_core::LazyLock<
    std::sync::Arc<::smithy4rs_core::schema::SchemaBuilder>,
> = ::smithy4rs_core::LazyLock::new(|| std::sync::Arc::new(
    ::smithy4rs_core::schema::Schema::structure_builder("test#InnerStruct", Vec::new()),
));
pub static SCHEMA: ::smithy4rs_core::LazyLock<
    ::smithy4rs_core::schema::SchemaRef,
> = ::smithy4rs_core::LazyLock::new(|| {
    (&*INNER_STRUCT_SCHEMA_BUILDER)
        .put_member("field_a", &STRING, Vec::new())
        .build()
});
pub static _SCHEMA_MEMBER_A: ::smithy4rs_core::LazyLock<
    &::smithy4rs_core::schema::SchemaRef,
> = ::smithy4rs_core::LazyLock::new(|| INNER_STRUCT_SCHEMA.expect_member("field_a"));
```

