### PR TITLE
Use nightly toolchain for mise tasks

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -12,8 +12,7 @@ cargo-binstall = "latest"
 "cargo:cargo-machete" = "latest"
 "cargo:cargo-expand" = "latest"
 rust = [
-  { profile = "minimal", version = "nightly", components = "rustfmt" },
-  { profile = "default", version = "1.90.0", components = "clippy" },
+  { profile = "minimal", version = "nightly", components = "rustfmt,clippy" },
 ]
 
 [tasks.dev]

--- a/core/benches/schema.rs
+++ b/core/benches/schema.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 use smithy4rs_core::{
     prelude::{HTTPChecksumRequiredTrait, HTTPQueryParamsTrait, HTTPQueryTrait},
-    schema::{Schema, StaticTraitId},
+    schema::StaticTraitId,
     smithy,
 };
 


### PR DESCRIPTION
Just use nightly for mise for now. This should fix CI breakage.