### PR TITLE
Move ci to just use cargo fmt directly

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -41,8 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v3
-      - run: mise fmt-all --check
+      - uses: actions-rust-lang/setup-rust-toolchain@v1 # v1.15.2
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - run: cargo +nightly fmt --all -- --check
 
   dependencies:
     name: Audit


### PR DESCRIPTION
Moves away from mise for cargo fmt check as that just keeps breaking.