### PR TITLE
Use `Into` for primitive builder setters

### DIFF
--- a/core-derive/src/builder.rs
+++ b/core-derive/src/builder.rs
@@ -199,6 +199,7 @@ impl BuilderFieldData {
         } else {
             quote! { #crate_ident::serde::Required::Set }
         };
+
         match &self.target {
             BuildTarget::Builable { shape, builder } => {
                 let builder_fn = Ident::new(&format!("{field_name}_builder"), Span::call_site());
@@ -216,8 +217,8 @@ impl BuilderFieldData {
             }
             BuildTarget::Primitive(ty) => {
                 quote! {
-                    pub fn #field_name(mut self, value: #ty) -> Self {
-                        self.#field_name = #wrapper(value);
+                    pub fn #field_name<T: Into<#ty>>(mut self, value: T) -> Self {
+                        self.#field_name = #wrapper(value.into());
                         self
                     }
                 }

--- a/core-derive/tests/expand/simple_struct.expanded.rs
+++ b/core-derive/tests/expand/simple_struct.expanded.rs
@@ -83,12 +83,12 @@ impl SimpleStructBuilder {
             field_c: None,
         }
     }
-    pub fn field_a(mut self, value: String) -> Self {
-        self.field_a = smithy4rs_core::serde::Required::Set(value);
+    pub fn field_a<T: Into<String>>(mut self, value: T) -> Self {
+        self.field_a = smithy4rs_core::serde::Required::Set(value.into());
         self
     }
-    pub fn field_b(mut self, value: i32) -> Self {
-        self.field_b = smithy4rs_core::serde::Required::Set(value);
+    pub fn field_b<T: Into<i32>>(mut self, value: T) -> Self {
+        self.field_b = smithy4rs_core::serde::Required::Set(value.into());
         self
     }
     pub fn field_c(mut self, value: Nested) -> Self {
@@ -313,8 +313,8 @@ impl NestedBuilder {
             field_a: smithy4rs_core::serde::Required::Unset,
         }
     }
-    pub fn field_a(mut self, value: String) -> Self {
-        self.field_a = smithy4rs_core::serde::Required::Set(value);
+    pub fn field_a<T: Into<String>>(mut self, value: T) -> Self {
+        self.field_a = smithy4rs_core::serde::Required::Set(value.into());
         self
     }
 }

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -124,7 +124,7 @@ pub fn validate_builder(c: &mut Criterion) {
 
 pub fn validate_shape(c: &mut Criterion) {
     let built_shape = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(1)
         .build()
         .expect("Shape should build");
@@ -153,7 +153,7 @@ pub fn unvalidated_shape(c: &mut Criterion) {
 
 pub fn builder_with_collections(c: &mut Criterion) {
     let builder = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(1);
     let list = vec![builder.clone(), builder.clone(), builder.clone()];
     let mut map = IndexMap::new();
@@ -173,7 +173,7 @@ pub fn builder_with_collections(c: &mut Criterion) {
 
 pub fn built_shape_with_collections(c: &mut Criterion) {
     let built = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(1)
         .build()
         .expect("Shape should build");
@@ -198,7 +198,7 @@ pub fn built_shape_with_collections(c: &mut Criterion) {
 // Primarily for comparison against set implementation.
 pub fn built_shape_with_list(c: &mut Criterion) {
     let built = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(1)
         .build()
         .expect("Shape should build");
@@ -214,17 +214,17 @@ pub fn built_shape_with_list(c: &mut Criterion) {
 
 pub fn built_shape_with_set(c: &mut Criterion) {
     let built1 = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(2)
         .build()
         .expect("Shape should build");
     let built2 = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(2)
         .build()
         .expect("Shape should build");
     let built3 = ValidatedStructBuilder::new()
-        .string("string".to_string())
+        .string("string")
         .required_int(3)
         .build()
         .expect("Shape should build");

--- a/json-codec/tests/roundtrip.rs
+++ b/json-codec/tests/roundtrip.rs
@@ -69,9 +69,9 @@ fn test_optional_data_without_value() {
 fn test_numbers_roundtrip() {
     let numbers = NumericTypesStructBuilder::new()
         .byte_val(42)
-        .short_val(1000)
+        .short_val(1000i16)
         .int_val(100000)
-        .long_val(1000000000000)
+        .long_val(1000000000000i64)
         .float_val(1.234)
         .double_val(1.23456789)
         .build()
@@ -85,9 +85,9 @@ fn test_numbers_roundtrip() {
 fn test_numbers_negative_values() {
     let numbers = NumericTypesStructBuilder::new()
         .byte_val(-42)
-        .short_val(-1000)
+        .short_val(-1000i16)
         .int_val(-100000)
-        .long_val(-1000000000000)
+        .long_val(-1000000000000i64)
         .float_val(-1.234)
         .double_val(-1.23456789)
         .build()


### PR DESCRIPTION
Uses `Into<T>` for primitive builder setters.
This is a bit more flexible than the existing approach and has no real impact on performance as `Into<Self>` calls are inlined.