### PR TITLE
Re-export derive macros from the core lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,8 +522,6 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1059,7 +1057,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smithy4rs-core",
- "smithy4rs-test-utils",
  "syn",
 ]
 
@@ -1067,12 +1064,10 @@ dependencies = [
 name = "smithy4rs-json-codec"
 version = "0.0.1"
 dependencies = [
- "indexmap",
  "itoa",
  "jiter",
  "ryu",
  "smithy4rs-core",
- "smithy4rs-core-derive",
  "smithy4rs-test-utils",
  "thiserror",
 ]
@@ -1081,9 +1076,7 @@ dependencies = [
 name = "smithy4rs-test-utils"
 version = "0.0.1"
 dependencies = [
- "indexmap",
  "smithy4rs-core",
- "smithy4rs-core-derive",
 ]
 
 [[package]]

--- a/core-derive/Cargo.toml
+++ b/core-derive/Cargo.toml
@@ -23,7 +23,6 @@ proc-macro-crate = "3.4.0"
 [dev-dependencies]
 macrotest = "1.0"
 smithy4rs-core = { path = "../core" }
-smithy4rs-test-utils = { path = "../test-utils" }
 
 [lints]
 workspace = true

--- a/core-derive/tests/expand/union.expanded.rs
+++ b/core-derive/tests/expand/union.expanded.rs
@@ -1,5 +1,5 @@
 use smithy4rs_core::prelude::{INTEGER, STRING, UNIT};
-use smithy4rs_core_derive::{Dummy, smithy_union};
+use smithy4rs_core_derive::{SmithyShape, smithy_union};
 #[smithy_schema(UNION)]
 #[smithy_union_enum]
 pub enum TestEnum {
@@ -13,3 +13,101 @@ pub enum TestEnum {
     #[doc(hidden)]
     Unknown(String),
 }
+const _: () = {
+    extern crate smithy4rs_core as _smithy4rs;
+    use _smithy4rs::schema::SchemaRef as _SchemaRef;
+    use _smithy4rs::schema::StaticSchemaShape as _StaticSchemaShape;
+    #[automatically_derived]
+    impl _StaticSchemaShape for TestEnum {
+        fn schema() -> &'static _SchemaRef {
+            &UNION
+        }
+    }
+};
+const _: () = {
+    extern crate smithy4rs_core as _smithy4rs;
+    use _smithy4rs::schema::SchemaRef as _SchemaRef;
+    use _smithy4rs::serde::serializers::Serializer as _Serializer;
+    use _smithy4rs::serde::serializers::SerializeWithSchema as _SerializeWithSchema;
+    use _smithy4rs::serde::serializers::StructSerializer as _StructSerializer;
+    use _smithy4rs::schema::Unit as _Unit;
+    #[automatically_derived]
+    impl _SerializeWithSchema for TestEnum {
+        fn serialize_with_schema<S: _Serializer>(
+            &self,
+            schema: &_SchemaRef,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error> {
+            let mut ser = serializer.write_struct(schema, 1)?;
+            match self {
+                TestEnum::A(val) => {
+                    ser.serialize_member_named("a", &_UNION_MEMBER_A, val)?
+                }
+                TestEnum::B(val) => {
+                    ser.serialize_member_named("b", &_UNION_MEMBER_B, val)?
+                }
+                TestEnum::C => ser.serialize_member_named("c", &_UNION_MEMBER_C, &_Unit)?,
+                TestEnum::Unknown(unknown) => ser.serialize_unknown(schema, unknown)?,
+            }
+            ser.end(schema)
+        }
+    }
+};
+const _: () = {
+    extern crate smithy4rs_core as _smithy4rs;
+    use _smithy4rs::schema::SchemaRef as _SchemaRef;
+    use _smithy4rs::serde::deserializers::Deserializer as _Deserializer;
+    use _smithy4rs::serde::deserializers::DeserializeWithSchema as _DeserializeWithSchema;
+    use _smithy4rs::serde::deserializers::Error as _DeserializerError;
+    use _smithy4rs::schema::Unit as _Unit;
+    #[automatically_derived]
+    impl<'de> _DeserializeWithSchema<'de> for TestEnum {
+        fn deserialize_with_schema<D>(
+            schema: &_SchemaRef,
+            deserializer: &mut D,
+        ) -> Result<Self, D::Error>
+        where
+            D: _Deserializer<'de>,
+        {
+            deserializer
+                .read_struct(
+                    schema,
+                    None,
+                    |option, member_schema, de| {
+                        if option.is_some() {
+                            return Err(
+                                D::Error::custom("Attempted to set union value twice"),
+                            );
+                        }
+                        if std::sync::Arc::ptr_eq(member_schema, &_UNION_MEMBER_A) {
+                            let value = String::deserialize_with_schema(
+                                member_schema,
+                                de,
+                            )?;
+                            return Ok(Some(TestEnum::A(value)));
+                        }
+                        if std::sync::Arc::ptr_eq(member_schema, &_UNION_MEMBER_B) {
+                            let value = i32::deserialize_with_schema(member_schema, de)?;
+                            return Ok(Some(TestEnum::B(value)));
+                        }
+                        if std::sync::Arc::ptr_eq(member_schema, &_UNION_MEMBER_C) {
+                            let _ = _Unit::deserialize_with_schema(member_schema, de)?;
+                            return Ok(Some(TestEnum::C));
+                        }
+                        Ok(Some(TestEnum::Unknown("unknown".to_string())))
+                    },
+                )?
+                .ok_or(D::Error::custom("Failed to deserialize union"))
+        }
+    }
+};
+const _: () = {
+    extern crate smithy4rs_core as _smithy4rs;
+    use _smithy4rs::serde::debug::DebugWrapper as _DebugWrapper;
+    #[automatically_derived]
+    impl std::fmt::Debug for TestEnum {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Debug::fmt(&_DebugWrapper::new(&UNION, self), f)
+        }
+    }
+};

--- a/core-derive/tests/expand/union.rs
+++ b/core-derive/tests/expand/union.rs
@@ -1,5 +1,5 @@
 use smithy4rs_core::prelude::{INTEGER, STRING, UNIT};
-use smithy4rs_core_derive::{Dummy, smithy_union};
+use smithy4rs_core_derive::{SmithyShape, smithy_union};
 
 smithy!("test#SimpleUnion": {
     union UNION {
@@ -10,7 +10,7 @@ smithy!("test#SimpleUnion": {
 });
 
 #[smithy_union]
-#[derive(Dummy)]
+#[derive(SmithyShape)]
 #[smithy_schema(UNION)]
 pub enum TestEnum {
     #[smithy_schema(A)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ downcast-rs.workspace = true
 regex.workspace = true
 fast-str.workspace = true
 temporal_rs.workspace = true
+smithy4rs-core-derive.workspace = true
 
 # <TODO> move to workspace
 pastey = "0.2.1"
@@ -31,7 +32,6 @@ log = "0.4.29"
 
 [dev-dependencies]
 serde_json = "1.0.148"
-smithy4rs-core-derive.workspace = true
 criterion.workspace = true
 
 [lints]

--- a/core/benches/documents.rs
+++ b/core/benches/documents.rs
@@ -1,14 +1,14 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use indexmap::IndexMap;
 use smithy4rs_core::{
+    IndexMap,
+    derive::SmithyShape,
     prelude::{INTEGER, STRING},
     schema::Document,
     serde::ShapeBuilder,
     smithy,
 };
-use smithy4rs_core_derive::SmithyShape;
 
 smithy!("com.example#Map": {
     map MAP_SCHEMA {

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -4,8 +4,9 @@ use std::hint::black_box;
 
 use bigdecimal::BigDecimal;
 use criterion::{Criterion, criterion_group, criterion_main};
-use indexmap::IndexMap;
 use smithy4rs_core::{
+    IndexMap,
+    derive::SmithyShape,
     prelude::*,
     serde::{
         ShapeBuilder,
@@ -13,7 +14,6 @@ use smithy4rs_core::{
     },
     smithy,
 };
-use smithy4rs_core_derive::SmithyShape;
 
 // ==== Test shapes ====
 smithy!("test#ValidationStruct": {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,6 +54,11 @@ pub use std::sync::LazyLock;
 pub use pastey;
 
 // =================================================================
+// Re-export Derive macros
+// =================================================================
+pub use smithy4rs_core_derive as derive;
+
+// =================================================================
 // High performance hashmaps
 // -------------------------
 // Faster Map and Set implementations used for internal types and Schemas.

--- a/core/src/schema/documents.rs
+++ b/core/src/schema/documents.rs
@@ -1,10 +1,9 @@
 use std::{error::Error, fmt::Debug, sync::LazyLock};
 
-use indexmap::IndexMap;
 use thiserror::Error;
 
 use crate::{
-    BigDecimal, BigInt, ByteBuffer, Instant,
+    BigDecimal, BigInt, ByteBuffer, IndexMap, Instant,
     schema::{
         SchemaShape, ShapeId, ShapeType,
         default::{Number, Value},
@@ -676,13 +675,12 @@ impl<T: TryFrom<Box<dyn Document>, Error = DocumentError>> TryFrom<Box<dyn Docum
 // ============================================================================
 
 pub(crate) mod default {
-    use bigdecimal::{BigDecimal, ToPrimitive};
-    use bytebuffer::ByteBuffer;
-    use indexmap::IndexMap;
-    use num_bigint::BigInt;
-    use temporal_rs::Instant;
+    use bigdecimal::ToPrimitive;
 
-    use crate::schema::{DocumentError, SchemaRef, SchemaShape, ShapeId, ShapeType};
+    use crate::{
+        BigDecimal, BigInt, ByteBuffer, IndexMap, Instant,
+        schema::{DocumentError, SchemaRef, SchemaShape, ShapeId, ShapeType},
+    };
 
     #[derive(Clone, PartialEq, Debug)]
     pub struct Document {

--- a/core/src/serde/adapter.rs
+++ b/core/src/serde/adapter.rs
@@ -289,11 +289,10 @@ impl<T: SerializeWithSchema> serde::Serialize for ValueWrapper<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use indexmap::IndexMap;
-    use smithy4rs_core_derive::SmithyShape;
-
     use super::*;
     use crate::{
+        IndexMap,
+        derive::SmithyShape,
         schema::{SchemaShape, prelude::*},
         smithy,
     };

--- a/core/src/serde/correction.rs
+++ b/core/src/serde/correction.rs
@@ -7,11 +7,9 @@
 //! For further discussion of Error correction see: [Smithy client error correction](https://smithy.io/2.0/spec/aggregate-types.html#client-error-correction).
 //!
 use bigdecimal::Zero;
-use bytebuffer::ByteBuffer;
-use indexmap::IndexMap;
 
 use crate::{
-    BigDecimal, BigInt, Instant,
+    BigDecimal, BigInt, ByteBuffer, IndexMap, Instant,
     schema::{Document, NULL},
     serde::{MaybeBuilt, serializers::SerializeWithSchema},
 };

--- a/core/src/serde/debug.rs
+++ b/core/src/serde/debug.rs
@@ -405,11 +405,10 @@ impl Debug for dyn SmithyTrait {
 #[cfg(test)]
 mod tests {
 
-    use indexmap::IndexMap;
-    use smithy4rs_core_derive::SmithyShape;
-
     use super::*;
     use crate::{
+        IndexMap,
+        derive::SmithyShape,
         schema::prelude::{MediaTypeTrait, STRING},
         smithy,
     };

--- a/core/src/serde/deserializers.rs
+++ b/core/src/serde/deserializers.rs
@@ -3,10 +3,8 @@
 //! TODO(docs): Implementation docs
 use std::{error::Error as StdError, fmt::Display};
 
-use indexmap::IndexMap;
-
 use crate::{
-    BigDecimal, BigInt, ByteBuffer, Instant,
+    BigDecimal, BigInt, ByteBuffer, IndexMap, Instant,
     schema::{Document, SchemaRef, SchemaShape, StaticSchemaShape},
 };
 

--- a/core/src/serde/documents.rs
+++ b/core/src/serde/documents.rs
@@ -1,9 +1,7 @@
 use std::fmt::Display;
 
-use indexmap::IndexMap;
-
 use crate::{
-    BigDecimal, BigInt, ByteBuffer, Instant,
+    BigDecimal, BigInt, ByteBuffer, IndexMap, Instant,
     schema::{
         Document, DocumentError, NULL, SchemaRef, ShapeId, ShapeType, StaticSchemaShape,
         default::Value,
@@ -554,10 +552,8 @@ impl Deserializer<'_> for DocumentDeserializer {
 mod tests {
     use std::str::FromStr;
 
-    use smithy4rs_core_derive::SmithyShape;
-
     use super::*;
-    use crate::{schema::prelude::*, smithy};
+    use crate::{derive::SmithyShape, schema::prelude::*, smithy};
 
     smithy!("com.example#Map": {
         map MAP_SCHEMA {

--- a/core/src/serde/validation.rs
+++ b/core/src/serde/validation.rs
@@ -1281,15 +1281,13 @@ enum SmithyConstraints {
 }
 impl ValidationError for SmithyConstraints {}
 
-// TODO(testing): Convert these to use common shapes from the test-utils crate.
 #[cfg(test)]
 #[allow(clippy::type_complexity)]
 mod tests {
-    use indexmap::IndexMap;
-    use smithy4rs_core_derive::SmithyShape;
-
     use super::*;
     use crate::{
+        IndexMap,
+        derive::SmithyShape,
         schema::prelude::{INTEGER, LengthTrait, PatternTrait, STRING, UniqueItemsTrait},
         serde::ShapeBuilder,
         smithy,

--- a/json-codec/Cargo.toml
+++ b/json-codec/Cargo.toml
@@ -13,16 +13,13 @@ version.workspace = true
 
 [dependencies]
 smithy4rs-core.workspace = true
-indexmap.workspace = true
 thiserror.workspace = true
 itoa = "1.0"
 ryu = "1.0"
 jiter.workspace = true
 
 [dev-dependencies]
-smithy4rs-core-derive.workspace = true
 smithy4rs-test-utils = { path = "../test-utils" }
-indexmap = { workspace = true, features = ["serde"] }
 
 [lints]
 workspace = true

--- a/json-codec/tests/nested_serialization_test.rs
+++ b/json-codec/tests/nested_serialization_test.rs
@@ -1,6 +1,8 @@
 // TODO(test): add some test utils for validating the serialized json outputs, perhaps snapshots would suffice
-use indexmap::IndexMap;
-use smithy4rs_core::serde::{ShapeBuilder, se::SerializeWithSchema};
+use smithy4rs_core::{
+    IndexMap,
+    serde::{ShapeBuilder, se::SerializeWithSchema},
+};
 use smithy4rs_json_codec::JsonSerializer;
 use smithy4rs_test_utils::*;
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -11,8 +11,6 @@ categories.workspace = true
 
 [dependencies]
 smithy4rs-core.workspace = true
-smithy4rs-core-derive.workspace = true
-indexmap.workspace = true
 
 [lints]
 workspace = true

--- a/test-utils/src/basic_types.rs
+++ b/test-utils/src/basic_types.rs
@@ -1,11 +1,11 @@
 use smithy4rs_core::{
     ByteBuffer, Instant,
+    derive::SmithyShape,
     schema::prelude::{
         BLOB, BOOLEAN, BYTE, DOUBLE, FLOAT, INTEGER, LONG, SHORT, STRING, TIMESTAMP,
     },
     smithy,
 };
-use smithy4rs_core_derive::SmithyShape;
 
 smithy!("test#IntegerList": {
     list INTEGER_LIST_SCHEMA {

--- a/test-utils/src/enums.rs
+++ b/test-utils/src/enums.rs
@@ -1,5 +1,7 @@
-use smithy4rs_core::smithy;
-use smithy4rs_core_derive::{SmithyShape, smithy_enum};
+use smithy4rs_core::{
+    derive::{SmithyShape, smithy_enum},
+    smithy,
+};
 
 smithy!("test#StringEnum": {
     enum SIMPLE_ENUM {

--- a/test-utils/src/nested.rs
+++ b/test-utils/src/nested.rs
@@ -1,9 +1,9 @@
-use indexmap::IndexMap;
 use smithy4rs_core::{
+    IndexMap,
+    derive::SmithyShape,
     schema::prelude::{INTEGER, STRING},
     smithy,
 };
-use smithy4rs_core_derive::SmithyShape;
 
 smithy!("test#InnerStruct": {
     structure INNER_STRUCT_SCHEMA {

--- a/test-utils/src/recursive.rs
+++ b/test-utils/src/recursive.rs
@@ -1,9 +1,9 @@
-use indexmap::IndexMap;
 use smithy4rs_core::{
+    IndexMap,
+    derive::SmithyShape,
     schema::prelude::{INTEGER, STRING},
     smithy,
 };
-use smithy4rs_core_derive::SmithyShape;
 
 smithy!("test#StringMap": {
     map STRING_MAP_SCHEMA {

--- a/test-utils/src/unions.rs
+++ b/test-utils/src/unions.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code)]
 
 use smithy4rs_core::{
+    derive::{SmithyShape, smithy_union},
     schema::{
         UNIT,
         prelude::{INTEGER, STRING},
     },
     smithy,
 };
-use smithy4rs_core_derive::{SmithyShape, smithy_union};
 
 smithy!("test#SimpleUnion": {
     union UNION {


### PR DESCRIPTION
Re-exports derive macros from the core library. This ensures the only dependency of generated shapes is the core lib.