### PR TITLE
Use fastStr in ShapeIds for performance boost

### DIFF
--- a/core/src/schema/documents.rs
+++ b/core/src/schema/documents.rs
@@ -1,4 +1,5 @@
 use std::{error::Error, fmt::Debug, sync::LazyLock};
+
 use thiserror::Error;
 
 use crate::{
@@ -675,7 +676,7 @@ impl<T: TryFrom<Box<dyn Document>, Error = DocumentError>> TryFrom<Box<dyn Docum
 
 pub(crate) mod default {
     use bigdecimal::ToPrimitive;
-    use fast_str::FastStr;
+
     use crate::{
         BigDecimal, BigInt, ByteBuffer, IndexMap, Instant,
         schema::{DocumentError, SchemaRef, SchemaShape, ShapeId, ShapeType},


### PR DESCRIPTION
I noticed that using FastStr's in shapeId's led to a reasonable performance boost (~20% faster) in some of our micro benchmarks